### PR TITLE
Stock changes record

### DIFF
--- a/Extension/XMLView/EditStock.xml
+++ b/Extension/XMLView/EditStock.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * This file is part of FacturaScripts
+ * Copyright (C) 2017-2020 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Carlos García Gómez  <carlos@facturascripts.com>
+ * @author José Antonio Cuello  <yopli2000@gmail.com>
+-->
+<view>
+    <rows>
+        <row type="actions">
+            <button type="modal" label='update-stock' color="warning" action="update-stock" icon="fas fa-dolly" />
+        </row>
+    </rows>
+
+    <modals>
+        <group name="update-stock" title="update-stock" icon="fas fa-dolly fa-fw">
+            <column name="idstock" display="none" order="0">
+                <widget type="text" fieldname="idstock" />
+            </column>
+            <column name="description" numcolumns="12" description="mov-stock-description">
+                <widget type="text" fieldname="mov-description" required="true" />
+            </column>
+            <column name="quantity" title="new-description" numcolumns="12" description="new-quantity-description">
+                <widget type="number" fieldname="mov-quantity" required="true" />
+            </column>
+        </group>
+    </modals>
+</view>


### PR DESCRIPTION
Now the variant stock is locked in the EditProduto controller. To make a change in the quantity in stock, you must press a new button for this task.
When pressing a modal is shown where to indicate the new quantity and the reason for the change. This generates a count record, being recorded within the stock movements.