### PR TITLE
Añadidos nuevos filtros al informe de stock

### DIFF
--- a/Controller/ReportStock.php
+++ b/Controller/ReportStock.php
@@ -90,21 +90,29 @@ class ReportStock extends ListController
         $this->addSearchFields($viewName, ['productos.descripcion', 'stocks.referencia']);
 
         // filters
+        $i18n = $this->toolBox()->i18n();
         $values = [
             [
-                'label' => $this->toolBox()->i18n()->trans('all'),
+                'label' => $i18n->trans('all'),
                 'where' => []
             ],
             [
-                'label' => $this->toolBox()->i18n()->trans('under-minimums'),
+                'label' => $i18n->trans('under-minimums'),
                 'where' => [new DataBaseWhere('disponible', 'field:stockmin', '<')]
             ],
             [
-                'label' => $this->toolBox()->i18n()->trans('excess'),
+                'label' => $i18n->trans('excess'),
                 'where' => [new DataBaseWhere('disponible', 'field:stockmax', '>')]
             ]
         ];
         $this->addFilterSelectWhere($viewName, 'type', $values);
+
+        $this->addFilterSelectWhere($viewName, 'status', [
+            ['label' => $i18n->trans('all'), 'where' => []],
+            ['label' => $i18n->trans('only-active'), 'where' => [new DataBaseWhere('productos.bloqueado', false)]],
+            ['label' => $i18n->trans('blocked'), 'where' => [new DataBaseWhere('productos.bloqueado', true)]],
+            ['label' => $i18n->trans('public'), 'where' => [new DataBaseWhere('productos.publico', true)]],
+        ]);
 
         $warehouses = $this->codeModel->all('almacenes', 'codalmacen', 'nombre');
         $this->addFilterSelect($viewName, 'codalmacen', 'warehouse', 'codalmacen', $warehouses);
@@ -114,6 +122,8 @@ class ReportStock extends ListController
 
         $families = $this->codeModel->all('familias', 'codfamilia', 'descripcion');
         $this->addFilterSelect($viewName, 'codfamilia', 'family', 'codfamilia', $families);
+
+        $this->addFilterCheckbox($viewName, 'secompra', 'for-purchase', 'productos.secompra');
 
         // disable buttons
         $this->setSettings($viewName, 'btnDelete', false);

--- a/Model/Join/StockProducto.php
+++ b/Model/Join/StockProducto.php
@@ -42,12 +42,13 @@ class StockProducto extends JoinModel
     }
 
     /**
-     * 
+     *
      * @return array
      */
     protected function getFields(): array
     {
         return [
+            'bloqueado' => 'productos.bloqueado',
             'cantidad' => 'stocks.cantidad',
             'codalmacen' => 'stocks.codalmacen',
             'codfabricante' => 'productos.codfabricante',
@@ -57,6 +58,7 @@ class StockProducto extends JoinModel
             'disponible' => 'stocks.disponible',
             'idproducto' => 'stocks.idproducto',
             'idstock' => 'stocks.idstock',
+            'nostock' => 'productos.nostock',
             'precio' => 'variantes.precio',
             'pterecibir' => 'stocks.pterecibir',
             'referencia' => 'stocks.referencia',
@@ -68,7 +70,7 @@ class StockProducto extends JoinModel
     }
 
     /**
-     * 
+     *
      * @return string
      */
     protected function getGroupFields(): string
@@ -77,7 +79,7 @@ class StockProducto extends JoinModel
     }
 
     /**
-     * 
+     *
      * @return string
      */
     protected function getSQLFrom(): string
@@ -88,7 +90,7 @@ class StockProducto extends JoinModel
     }
 
     /**
-     * 
+     *
      * @return array
      */
     protected function getTables(): array

--- a/XMLView/StockProducto.xml
+++ b/XMLView/StockProducto.xml
@@ -57,4 +57,10 @@
             <widget type="money" fieldname="precio" />
         </column>
     </columns>
+    <rows>
+        <row type="status">
+            <option color="danger" title="locked" fieldname="bloqueado">1</option>
+            <option color="info" title="no-stock" fieldname="nostock">1</option>
+        </row>
+    </rows>
 </view>


### PR DESCRIPTION
Se ha añadido la posibilidad de filtrar por:
- Estado del producto: Todos, Activos, Bloqueados o Públicos
- Se compra

Se ha añadido row status para colorear y ayudar de manera visual a localizar los registros bloqueados y los que no controlan stock.