### PR TITLE
Añadido recalculo de stock del producto

### DIFF
--- a/Extension/XMLView/SettingsDefault.xml
+++ b/Extension/XMLView/SettingsDefault.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<view>
+    <columns>
+        <group name="products">
+            <column name="stock_rebuild" title="rebuild_stock_after_moviments" numcolumns="3" order="130">
+                <widget type="checkbox" fieldname="stock_rebuild"/>
+            </column>
+        </group>
+    </columns>
+</view>

--- a/Lib/StockRebuildManager.php
+++ b/Lib/StockRebuildManager.php
@@ -173,91 +173,71 @@ class StockRebuildManager
 
     protected static function setPterecibir(array &$stockData, string $codalmacen): void
     {
-        $apply = function (string $table, string $field) use (&$stockData, $codalmacen): void {
-            $linesTable = 'lineas' . $table;
-            if (false === static::db()->tableExists($linesTable)) {
-                return;
+        if (false === static::db()->tableExists('lineaspedidosprov')) {
+            return;
+        }
+
+        $sql = "SELECT l.referencia,"
+            . " SUM(CASE WHEN l.cantidad > l.servido THEN l.cantidad - l.servido ELSE 0 END) as pte"
+            . " FROM lineaspedidosprov l"
+            . " JOIN pedidosprov p ON l.idpedido = p.idpedido"
+            . " JOIN variantes v ON v.referencia = l.referencia"
+            . " WHERE l.referencia IS NOT NULL";
+
+        if (null !== static::$idproducto) {
+            $sql .= " AND l.idproducto = " . static::db()->var2str(static::$idproducto);
+        }
+
+        $sql .= " AND l.actualizastock = '2'"
+            . " AND p.codalmacen = " . static::db()->var2str($codalmacen)
+            . " GROUP BY 1;";
+        foreach (static::db()->select($sql) as $row) {
+            $ref = trim($row['referencia']);
+            if (!isset($stockData[$ref])) {
+                $stockData[$ref] = [
+                    'cantidad' => 0,
+                    'codalmacen' => $codalmacen,
+                    'referencia' => $ref,
+                    'reservada' => 0
+                ];
             }
 
-            $sql = "SELECT l.referencia,"
-                . " SUM(CASE WHEN l.cantidad > l.servido THEN l.cantidad - l.servido ELSE 0 END) as pte"
-                . " FROM {$linesTable} l"
-                . " JOIN {$table} p ON p.{$field} = l.{$field}"
-                . " JOIN variantes v ON v.referencia = l.referencia"
-                . " WHERE l.referencia IS NOT NULL";
-
-            if (null !== static::$idproducto) {
-                $sql .= " AND l.idproducto = " . static::db()->var2str(static::$idproducto);
-            }
-
-            $sql .= " AND l.actualizastock = '2'"
-                . " AND p.codalmacen = " . static::db()->var2str($codalmacen)
-                . " GROUP BY 1;";
-
-            foreach (static::db()->select($sql) as $row) {
-                $ref = trim($row['referencia']);
-                if (!isset($stockData[$ref])) {
-                    $stockData[$ref] = [
-                        'cantidad' => 0,
-                        'codalmacen' => $codalmacen,
-                        'referencia' => $ref,
-                        'reservada' => 0,
-                        'pterecibir' => 0,
-                    ];
-                }
-
-                $stockData[$ref]['pterecibir'] += (float)$row['pte'];
-            }
-        };
-
-        // Aplicar para los diferentes tipos de documentos de proveedor
-        $apply('pedidosprov', 'idpedido');
-        $apply('albaranesprov', 'idalbaran');
-        $apply('facturasprov', 'idfactura');
+            $stockData[$ref]['pterecibir'] = (float)$row['pte'];
+        }
     }
-    
+
     protected static function setReservada(array &$stockData, string $codalmacen): void
     {
-        $apply = function (string $table, string $field) use (&$stockData, $codalmacen): void {
-            $linesTable = 'lineas' . $table;
-            if (false === static::db()->tableExists($linesTable)) {
-                return;
+        if (false === static::db()->tableExists('lineaspedidoscli')) {
+            return;
+        }
+
+        $sql = "SELECT l.referencia,"
+            . " SUM(CASE WHEN l.cantidad > l.servido THEN l.cantidad - l.servido ELSE 0 END) as reservada"
+            . " FROM lineaspedidoscli l"
+            . " JOIN pedidoscli p ON l.idpedido = p.idpedido"
+            . " JOIN variantes v ON v.referencia = l.referencia"
+            . " WHERE l.referencia IS NOT NULL";
+
+        if (null !== static::$idproducto) {
+            $sql .= " AND l.idproducto = " . static::db()->var2str(static::$idproducto);
+        }
+
+        $sql .= " AND l.actualizastock = '-2'"
+            . " AND p.codalmacen = " . static::db()->var2str($codalmacen)
+            . " GROUP BY 1;";
+        foreach (static::db()->select($sql) as $row) {
+            $ref = trim($row['referencia']);
+            if (!isset($stockData[$ref])) {
+                $stockData[$ref] = [
+                    'cantidad' => 0,
+                    'codalmacen' => $codalmacen,
+                    'pterecibir' => 0,
+                    'referencia' => $ref
+                ];
             }
 
-            $sql = "SELECT l.referencia,"
-                . " SUM(CASE WHEN l.cantidad > l.servido THEN l.cantidad - l.servido ELSE 0 END) as reservada"
-                . " FROM {$linesTable} l"
-                . " JOIN {$table} p ON p.{$field} = l.{$field}"
-                . " JOIN variantes v ON v.referencia = l.referencia"
-                . " WHERE l.referencia IS NOT NULL";
-
-            if (null !== static::$idproducto) {
-                $sql .= " AND l.idproducto = " . static::db()->var2str(static::$idproducto);
-            }
-
-            $sql .= " AND l.actualizastock = '-2'"
-                . " AND p.codalmacen = " . static::db()->var2str($codalmacen)
-                . " GROUP BY 1;";
-
-            foreach (static::db()->select($sql) as $row) {
-                $ref = trim($row['referencia']);
-                if (!isset($stockData[$ref])) {
-                    $stockData[$ref] = [
-                        'cantidad' => 0,
-                        'codalmacen' => $codalmacen,
-                        'pterecibir' => 0,
-                        'referencia' => $ref,
-                        'reservada' => 0,
-                    ];
-                }
-
-                $stockData[$ref]['reservada'] += (float)$row['reservada'];
-            }
-        };
-
-        // Aplicar para los diferentes tipos de documentos de cliente
-        $apply('pedidoscli', 'idpedido');
-        $apply('albaranescli', 'idalbaran');
-        $apply('facturascli', 'idfactura');
+            $stockData[$ref]['reservada'] = (float)$row['reservada'];
+        }
     }
 }

--- a/Worker/UpdateStockMovements.php
+++ b/Worker/UpdateStockMovements.php
@@ -23,7 +23,9 @@ use FacturaScripts\Core\DataSrc\Almacenes;
 use FacturaScripts\Core\Model\Producto;
 use FacturaScripts\Core\Model\WorkEvent;
 use FacturaScripts\Core\Template\WorkerClass;
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Where;
+use FacturaScripts\Plugins\StockAvanzado\Lib\StockRebuildManager;
 use FacturaScripts\Plugins\StockAvanzado\Model\MovimientoStock;
 
 class UpdateStockMovements extends WorkerClass
@@ -74,6 +76,11 @@ class UpdateStockMovements extends WorkerClass
                     $offset += $limit;
                 } while (count($movements) > 0);
             }
+        }
+
+        $rebuild = (bool)Tools::settings('default', 'stock_rebuild', false) === true ?? false;
+        if ($rebuild) {
+            StockRebuildManager::rebuild($product->idproducto);
         }
 
         return $this->done();


### PR DESCRIPTION
De manera configurable en el panel de Administración se puede indicar si al finalizar la reconstrucción de movimientos se debe recalcular el stock para el producto.