### PR TITLE
Tarea 4277 filtro reconstruir stock

### DIFF
--- a/Assets/JS/EditProductoButtons.js
+++ b/Assets/JS/EditProductoButtons.js
@@ -1,0 +1,23 @@
+(() => {
+    const rules = [
+        ['rebuild-movements', 'fa-solid fa-repeat fa-fw'],
+        ['rebuild-stock', 'fa-solid fa-dolly fa-fw']
+    ];
+    function patchButtons() {
+        rules.forEach(([action, iconClass]) => {
+            document
+                .querySelectorAll(`#formListMovimientoStock button[onclick*="${action}"]`)
+                .forEach((btn) => {
+                    const text = btn.getAttribute('title');
+                    if (!text) {
+                        return;
+                    }
+
+                    btn.innerHTML = `<i class="${iconClass}"></i> <span class="text-nowrap">${text}</span>`;
+                });
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', patchButtons);
+    document.addEventListener('shown.bs.tab', patchButtons);
+})();

--- a/Extension/Controller/EditProducto.php
+++ b/Extension/Controller/EditProducto.php
@@ -24,6 +24,7 @@ use FacturaScripts\Core\DataSrc\Almacenes;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Where;
 use FacturaScripts\Core\WorkQueue;
+use FacturaScripts\Dinamic\Lib\AssetManager;
 use FacturaScripts\Dinamic\Lib\StockMovementManager;
 use FacturaScripts\Dinamic\Lib\StockRebuildManager;
 use FacturaScripts\Dinamic\Model\ConteoStock;
@@ -94,6 +95,9 @@ class EditProducto
     protected function createViews(): Closure
     {
         return function () {
+            $route = Tools::config('route');
+            AssetManager::addJs($route . '/Plugins/StockAvanzado/Assets/JS/EditProductoButtons.js');
+
             // marcamos la columna de cantidad en el stock como no editable
             $this->tab('EditStock')->disableColumn('quantity', false, 'true');
 
@@ -130,7 +134,7 @@ class EditProducto
             if ($this->user->admin) {
                 $this->addButton($viewName, [
                     'action' => 'rebuild-movements',
-                    'color' => 'warning',
+                    'color' => 'info',
                     'confirm' => true,
                     'icon' => 'fa-solid fa-repeat',
                     'label' => 'rebuild-movements'

--- a/Extension/Controller/EditProducto.php
+++ b/Extension/Controller/EditProducto.php
@@ -225,6 +225,18 @@ class EditProducto
                 return;
             }
 
+            // si hay reconstrucción de movimientos en curso, no reconstruimos el stock
+            $where = [
+                Where::eq('done', false),
+                Where::in('name', ['Model.Producto.rebuildStockMovements', 'Model.Producto.updateStockMovements']),
+                Where::eq('value', (string)$product->id())
+            ];
+
+            if (WorkEvent::count($where) > 0) {
+                Tools::log()->warning('wait-stock-movements-rebuild');
+                return;
+            }
+
             StockRebuildManager::rebuild($product->idproducto);
 
             Tools::log()->notice('rebuilt-stock');

--- a/Extension/Controller/ListProducto.php
+++ b/Extension/Controller/ListProducto.php
@@ -20,7 +20,9 @@
 namespace FacturaScripts\Plugins\StockAvanzado\Extension\Controller;
 
 use Closure;
+use FacturaScripts\Core\Base\DataBase;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Lib\StockRebuildManager;
 use FacturaScripts\Dinamic\Model\MovimientoStock;
 use FacturaScripts\Dinamic\Model\Producto;
@@ -47,7 +49,7 @@ class ListProducto
         };
     }
 
-    protected function execPreviousAction(): Closure
+    protected function execAfterAction(): Closure
     {
         return function ($action) {
             if ($action === 'rebuild-stock') {
@@ -59,29 +61,48 @@ class ListProducto
     protected function rebuildStockAction(): Closure
     {
         return function () {
-            // si no hay movimientos, no hacemos nada
             if (MovimientoStock::count() === 0) {
                 Tools::log()->warning('no-movements-to-rebuild-stock');
                 return;
             }
 
-            // si no hay productos, no hacemos nada
-            $total = (int)$this->request->get('total', Producto::count());
+            // en este punto, $this->views['ListStock']->where ya está poblado
+            // por el flujo normal (processFormData + loadData se ejecutaron antes de execAfterAction)
+            $whereSql = Where::multiSqlLegacy($this->views['ListStock']->where);
+
+            $from = 'stocks'
+                . ' LEFT JOIN variantes ON variantes.referencia = stocks.referencia'
+                . ' LEFT JOIN productos ON productos.idproducto = variantes.idproducto';
+
+            $db = new DataBase();
+
+            $total = (int)$this->request->get('total', -1);
+            if ($total < 0) {
+                $rows = $db->select('SELECT COUNT(DISTINCT stocks.idproducto) as total FROM ' . $from . $whereSql);
+                $total = (int)($rows[0]['total'] ?? 0);
+            }
+
             if (empty($total)) {
                 Tools::log()->warning('no-products');
                 return;
             }
 
-            // procesamos los productos de uno en uno, redirigiendo a la misma página
             $offset = (int)$this->request->get('offset', 0);
-            foreach (Producto::all([], [], $offset, 1) as $product) {
-                StockRebuildManager::rebuild($product->id());
-                Tools::log()->info('rebuilding-stock', ['%reference%' => $product->referencia, '%offset%' => $offset + 1, '%total%' => $total]);
-                $this->redirect('?activetab=ListStock&action=rebuild-stock&total=' . $total . '&offset=' . ($offset + 1), 1);
+            $rows = $db->select(
+                'SELECT DISTINCT stocks.idproducto FROM ' . $from . $whereSql
+                . ' ORDER BY stocks.idproducto LIMIT 1 OFFSET ' . $offset
+            );
+
+            if (empty($rows)) {
+                Tools::log()->info('rebuilding-stock-finished', ['total' => $total]);
                 return;
             }
 
-            Tools::log()->info('rebuilding-stock-finished', ['total' => $total]);
+            $product = new Producto();
+            $product->load((int)$rows[0]['idproducto']);
+            StockRebuildManager::rebuild($product->id());
+            Tools::log()->info('rebuilding-stock', ['%reference%' => $product->referencia, '%offset%' => $offset + 1, '%total%' => $total]);
+            $this->redirect('?activetab=ListStock&action=rebuild-stock&total=' . $total . '&offset=' . ($offset + 1), 1);
         };
     }
 }

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -27,5 +27,6 @@
     "transfer-stock": "Transferir stock",
     "valued-stock-cost": "Stock valorado a coste",
     "valued-stock-price": "Stock valorado a precio",
+    "wait-stock-movements-rebuild": "Reconstruccion de stock no completada, espera que se finalice la reconstruccion de movimientos",
     "without-stock-count": "Excluir conteos"
 }


### PR DESCRIPTION
El botón de reconstrucción de stock ha sido mejorado para respetar los filtros activos en la pestaña de stock. En el original, el proceso siempre reconstruía todos los productos del sistema ignorando cualquier filtro.
  Ahora, si tienes activo por ejemplo un filtro de familia o de almacén, la reconstrucción solo afecta a los productos que muestra ese filtro. Para conseguirlo, el proceso se ha movido al hook execAfterAction en lugar de execPreviousAction, porque los filtros de la vista solo están disponibles después de que el framework los haya cargado, y execAfterAction es el punto del ciclo de vida donde eso ya ha ocurrido. El comportamiento sin filtros es idéntico al original: reconstruye todo.