### PR TITLE
Tarea4277-filtroboton reconstruirStock

### DIFF
--- a/Extension/Controller/ListProducto.php
+++ b/Extension/Controller/ListProducto.php
@@ -20,7 +20,9 @@
 namespace FacturaScripts\Plugins\StockAvanzado\Extension\Controller;
 
 use Closure;
+use FacturaScripts\Core\Base\DataBase;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Lib\StockRebuildManager;
 use FacturaScripts\Dinamic\Model\MovimientoStock;
 use FacturaScripts\Dinamic\Model\Producto;
@@ -47,7 +49,7 @@ class ListProducto
         };
     }
 
-    protected function execPreviousAction(): Closure
+    protected function execAfterAction(): Closure
     {
         return function ($action) {
             if ($action === 'rebuild-stock') {
@@ -59,29 +61,48 @@ class ListProducto
     protected function rebuildStockAction(): Closure
     {
         return function () {
-            // si no hay movimientos, no hacemos nada
             if (MovimientoStock::count() === 0) {
                 Tools::log()->warning('no-movements-to-rebuild-stock');
                 return;
             }
 
-            // si no hay productos, no hacemos nada
-            $total = (int)$this->request->get('total', Producto::count());
+            // en este punto, $this->views['ListStock']->where ya está poblado
+            // por el flujo normal (processFormData + loadData se ejecutaron antes de execAfterAction)
+            $whereSql = Where::multiSqlLegacy($this->views['ListStock']->where);
+
+            $from = 'stocks'
+                . ' LEFT JOIN variantes ON variantes.referencia = stocks.referencia'
+                . ' LEFT JOIN productos ON productos.idproducto = variantes.idproducto';
+
+            $db = new DataBase();
+
+            $total = (int)$this->request->get('total', -1);
+            if ($total < 0) {
+                $rows = $db->select('SELECT COUNT(DISTINCT stocks.idproducto) as total FROM ' . $from . $whereSql);
+                $total = (int)($rows[0]['total'] ?? 0);
+            }
+
             if (empty($total)) {
                 Tools::log()->warning('no-products');
                 return;
             }
 
-            // procesamos los productos de uno en uno, redirigiendo a la misma página
             $offset = (int)$this->request->get('offset', 0);
-            foreach (Producto::all([], [], $offset, 1) as $product) {
-                StockRebuildManager::rebuild($product->id());
-                Tools::log()->info('rebuilding-stock', ['%reference%' => $product->referencia, '%offset%' => $offset + 1, '%total%' => $total]);
-                $this->redirect('?activetab=ListStock&action=rebuild-stock&total=' . $total . '&offset=' . ($offset + 1), 1);
+            $rows = $db->select(
+                'SELECT DISTINCT stocks.idproducto FROM ' . $from . $whereSql
+                . ' ORDER BY stocks.idproducto LIMIT 1 OFFSET ' . $offset
+            );
+
+            if (empty($rows)) {
+                Tools::log()->info('rebuilding-stock-finished', ['total' => $total]);
                 return;
             }
 
-            Tools::log()->info('rebuilding-stock-finished', ['total' => $total]);
+            $product = new Producto();
+            $product->load((int)$rows[0]['idproducto']);
+            StockRebuildManager::rebuild($product->id());
+            Tools::log()->info('rebuilding-stock', ['%reference%' => $product->referencia, '%offset%' => $offset + 1, '%total%' => $total]);
+            $this->redirect('?activetab=ListStock&action=rebuild-stock&total=' . $total . '&offset=' . ($offset + 1), 1);
         };
     }
 }


### PR DESCRIPTION
El botón de reconstrucción de stock ha sido mejorado para respetar los filtros activos en la pestaña de stock. En el original, el proceso siempre reconstruía todos los productos del sistema ignorando cualquier filtro.
Ahora, si tienes activo por ejemplo un filtro de familia o de almacén, la reconstrucción solo afecta a los productos que muestra ese filtro. Para conseguirlo, el proceso se ha movido al hook execAfterAction en lugar de execPreviousAction, porque los filtros de la vista solo están disponibles después de que el framework los haya cargado, y execAfterAction es el punto del ciclo de vida donde eso ya ha ocurrido. El comportamiento sin filtros es idéntico al original: reconstruye todo.